### PR TITLE
Feature: Allow renaming config before mounting it

### DIFF
--- a/ignore.conf.sample
+++ b/ignore.conf.sample
@@ -16,4 +16,8 @@ DemonRem
 # The RClone config named 'DemonRem' will now be skipped while auto-mounting and similarly
 # also be skipped while un-mounting.
 
-# Leave atleast ONE line after the last config.
+
+# <ENTER THE VALUES BELOW THIS LINE>
+
+
+# Leave atleast ONE line after the last config. Ideally, this comment should be the last line in this file.

--- a/rename.conf.sample
+++ b/rename.conf.sample
@@ -1,0 +1,28 @@
+# Lines where the FIRST character is a hash (#) will be ignored.
+#
+# This file SHOULD contain the names of the configs that are to be MOUNTED WITH DIFFERENT NAMES
+# While creating directories for these configs inside the root directory, the name of the directory
+# will be taken from THIS FILE instead of using the name of the config.
+#
+# This file should contain data in the form of:
+#       <ORIGINAL NAME OF CONFIG> -> <TITLE FOR THE DIRECTORY>
+#
+# The name of the config should not include the opening or closing square brackets.
+#
+# For example, a valid entry for this file will be:
+#       DemonRem -> DemonRem; Root
+# The above line will ensure that the config `DemonRem` is mounted to a directory named `DemonRem; Root`
+# inside the root directory instead of `DemonRem`.
+#
+# The value on the left side of the "->" except leading or trailing spaces will be treated as the original
+# name of the config, and similarly, any value on the right of the "->" sign except leading and trailing
+# spaces will be used as the name of the directory.
+#
+# If the value on either side of the "->" has nothing except from empty spaces, the entire line will be ignored.
+
+
+# <ENTER THE VALUES BELOW THIS LINE>
+
+
+# Leave atleast ONE LINE after the last value. 
+# Ideally, this comment should be the last line in this file.


### PR DESCRIPTION
Allow customizing the titles of the directories to which each config
is mounted.

Add sample configuration file containing information on how to add data
to the file so that the script can parse the data and mount accordingly.

Minor changes to the sample configuration file for ignore list, attempt
explaining stuff in a clear(er) manner.

Minor changes made to code documentation to tidy up the code and clearly
explain the logic.